### PR TITLE
beat, heap: introduce priority queue based on response time order

### DIFF
--- a/beater.go
+++ b/beater.go
@@ -164,8 +164,8 @@ func (b *beater) delete(endpoint string) error {
 	}
 
 	for i, node := range b.nodes() {
-		// We don't need to delete the node and remove the
-		// 'b.members' right away; add/delete nodes means
+		// We don't need to delete a node and remove it
+		// from 'b.members'; add/delete nodes means
 		// applying them in the next 'p.beat'.
 		if node == endpoint {
 			b.mu.Lock()

--- a/heap.go
+++ b/heap.go
@@ -17,6 +17,7 @@ func (p *priorityQueue) add(key string, spent time.Duration) {
 	heap.Push(p, item{key, spent})
 }
 
+// keys does not return a sorted result.
 func (p priorityQueue) keys() (res []string) {
 	res = make([]string, 0, len(p))
 	for _, item := range p {

--- a/heap.go
+++ b/heap.go
@@ -1,0 +1,40 @@
+package redgla
+
+import (
+	"container/heap"
+	"time"
+)
+
+// priorityQueue sorts the nodes in order of fastest response time.
+type priorityQueue []item
+
+type item struct {
+	key   string
+	spent time.Duration
+}
+
+func (p *priorityQueue) add(key string, spent time.Duration) {
+	heap.Push(p, item{key, spent})
+}
+
+func (p priorityQueue) keys() (res []string) {
+	res = make([]string, 0, len(p))
+	for _, item := range p {
+		res = append(res, item.key)
+	}
+	return
+}
+
+// heap.Interface boilerplate
+func (p priorityQueue) Len() int            { return len(p) }
+func (p priorityQueue) Less(i, j int) bool  { return p[i].spent < p[j].spent }
+func (p priorityQueue) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p *priorityQueue) Push(x interface{}) { *p = append(*p, x.(item)) }
+func (p *priorityQueue) Pop() interface{} {
+	old := *p
+	n := len(old)
+	x := old[n-1]
+	old[n-1] = item{}
+	*p = old[0 : n-1]
+	return x
+}

--- a/heap_test.go
+++ b/heap_test.go
@@ -1,0 +1,35 @@
+package redgla
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	var p priorityQueue
+
+	var (
+		exptimeA = time.Duration(2 * time.Second)
+		exptimeB = time.Duration(3 * time.Second)
+		exptimeC = time.Duration(5 * time.Second)
+		exptimeD = time.Duration(15 * time.Second)
+		exptimeE = time.Duration(1 * time.Second)
+
+		wants = []string{"e", "a", "b", "c", "d"}
+	)
+
+	p.add("b", exptimeB)
+	p.add("a", exptimeA)
+	p.add("c", exptimeC)
+	p.add("d", exptimeD)
+	p.add("e", exptimeE)
+
+	heap.Init(&p)
+	for _, want := range wants {
+		res := heap.Pop(&p).(item)
+		if res.key != want {
+			t.Fatalf("TestPriorityQueue: want %v got %v", want, res.key)
+		}
+	}
+}

--- a/heap_test.go
+++ b/heap_test.go
@@ -16,7 +16,7 @@ func TestPriorityQueue(t *testing.T) {
 		exptimeD = time.Duration(15 * time.Second)
 		exptimeE = time.Duration(1 * time.Second)
 
-		wants = []string{"e", "a", "b", "c", "d"}
+		want = []string{"e", "a", "b", "c", "d"}
 	)
 
 	p.add("b", exptimeB)
@@ -26,10 +26,10 @@ func TestPriorityQueue(t *testing.T) {
 	p.add("e", exptimeE)
 
 	heap.Init(&p)
-	for _, want := range wants {
+	for _, expect := range want {
 		res := heap.Pop(&p).(item)
-		if res.key != want {
-			t.Fatalf("TestPriorityQueue: want %v got %v", want, res.key)
+		if res.key != expect {
+			t.Fatalf("TestPriorityQueue: want %v got %v", expect, res.key)
 		}
 	}
 }


### PR DESCRIPTION
If using redgla for "Stable" purposes, we'll be making requests to one of several candidate endpoints. In this case, we want to make the request to the node with the fastest response. 
To accomplish this, we introduce a priority queue to store responses in order of speed during the heartbeat process.